### PR TITLE
Improve readability of action type generics

### DIFF
--- a/Sources/ActionHolder.swift
+++ b/Sources/ActionHolder.swift
@@ -1,16 +1,16 @@
 import Foundation
 
-public struct ActionHolder <A: Equatable> {
-  let origin: A
-  var modified: A
+public struct ActionHolder <Action: JanetAction> {
+  let origin: Action
+  var modified: Action
   
-  public static func create(action: A) -> ActionHolder<A> {
+  public static func create(action: Action) -> ActionHolder<Action> {
     return ActionHolder(origin: action,
                         modified: action)
   }
   
   func isOrigin(action: Any) -> Bool {
-    guard let castedAction = action as? A else {
+    guard let castedAction = action as? Action else {
       return false
     }
     return self.origin == castedAction
@@ -18,7 +18,7 @@ public struct ActionHolder <A: Equatable> {
 }
 
 extension ActionHolder: Equatable {
-  public static func == (lhs: ActionHolder<A>, rhs: ActionHolder<A>) -> Bool {
+  public static func == (lhs: ActionHolder<Action>, rhs: ActionHolder<Action>) -> Bool {
     return lhs.origin == rhs.origin && lhs.modified == rhs.modified
   }
 }

--- a/Sources/ActionService.swift
+++ b/Sources/ActionService.swift
@@ -9,7 +9,7 @@ public protocol ActionService: class {
 }
 
 public protocol TypedActionService: ActionService {
-  associatedtype ServiceAction: Equatable
+  associatedtype ServiceAction: JanetAction
   func send(action: ActionHolder<ServiceAction>) throws
   func cancel(action: ActionHolder<ServiceAction>)
 }

--- a/Sources/ActionServiceCallback.swift
+++ b/Sources/ActionServiceCallback.swift
@@ -4,29 +4,29 @@ import RxSwift
 public final class ActionServiceCallback {
   let pipeline: SharedPipeline
   
-  init(pipeline: PublishSubject<Any>) {
+  init(pipeline: SharedPipeline) {
     self.pipeline = pipeline
   }
   
-  func onStart<T: Equatable>(holder: ActionHolder<T>) {
+  func onStart<T: JanetAction>(holder: ActionHolder<T>) {
     pipeline.onNext(
       (holder, ActionState.start(holder.modified))
     )
   }
   
-  func onProgress<T: Equatable>(holder: ActionHolder<T>, progress: Double) {
+  func onProgress<T: JanetAction>(holder: ActionHolder<T>, progress: Double) {
     pipeline.onNext(
       (holder, ActionState.progress(holder.modified, progress))
     )
   }
   
-  func onSuccess<T: Equatable>(holder: ActionHolder<T>) {
+  func onSuccess<T: JanetAction>(holder: ActionHolder<T>) {
     pipeline.onNext(
       (holder, ActionState.success(holder.modified))
     )
   }
   
-  func onError<T: Equatable>(holder: ActionHolder<T>, error: Error) {
+  func onError<T: JanetAction>(holder: ActionHolder<T>, error: Error) {
     pipeline.onNext(
       (holder, ActionState.error(holder.modified, error))
     )

--- a/Sources/ActionState.swift
+++ b/Sources/ActionState.swift
@@ -1,13 +1,13 @@
 import Foundation
 import RxSwift
 
-public enum ActionState<A: Equatable> {
-  case start(A)
-  case progress(A, Double)
-  case success(A)
-  case error(A, Error)
+public enum ActionState <Action: JanetAction> {
+  case start(Action)
+  case progress(Action, Double)
+  case success(Action)
+  case error(Action, Error)
   
-  public func action() -> A {
+  public func action() -> Action {
     switch self {
     case .start(let action):
       return action
@@ -22,13 +22,13 @@ public enum ActionState<A: Equatable> {
   
   public var isCompleted: Bool {
     switch self {
-    case .start(_):
+    case .start:
       fallthrough
-    case .progress(_, _):
+    case .progress:
       return false
-    case .success(_):
+    case .success:
       fallthrough
-    case .error(_, _):
+    case .error:
       return true
     }
   }

--- a/Sources/Janet.swift
+++ b/Sources/Janet.swift
@@ -15,7 +15,7 @@ public final class Janet {
     }
   }
   
-  func send<A: Equatable>(action: A) -> Observable<ActionState<A>> {
+  func send<A: JanetAction>(action: A) -> Observable<ActionState<A>> {
     return pipeline.asObservable()
       .filter { pair in
         pair is ActionPair<A>
@@ -32,7 +32,7 @@ public final class Janet {
       }
   }
   
-  func doSend<A: Equatable>(action: A) {
+  func doSend<A: JanetAction>(action: A) {
     let serviceOptional = findService(A.self)
     guard let service = serviceOptional else {
       assertionFailure("Could not found service for \(action)")
@@ -41,7 +41,7 @@ public final class Janet {
     service.send(action: ActionHolder.create(action: action))
   }
 
-  func doCancel<A: Equatable>(action: A) {
+  func doCancel<A: JanetAction>(action: A) {
     let actionHolder = ActionHolder.create(action: action)
     callback.onError(holder: actionHolder, error: JanetError.cancelled)
     let serviceOptional = findService(A.self)

--- a/Sources/JanetTypes.swift
+++ b/Sources/JanetTypes.swift
@@ -1,5 +1,7 @@
 import Foundation
 import RxSwift
 
-internal typealias ActionPair<T: Equatable> = (ActionHolder<T>, ActionState<T>)
+public typealias JanetAction = Equatable
+
+internal typealias ActionPair <Action: JanetAction> = (ActionHolder<Action>, ActionState<Action>)
 internal typealias SharedPipeline = PublishSubject<Any>

--- a/Tests/SwiftyJanetTests/TestDoubles/MockService.swift
+++ b/Tests/SwiftyJanetTests/TestDoubles/MockService.swift
@@ -1,7 +1,7 @@
 import SwiftyJanet
 import Foundation
 
-class MockService<T: Equatable>: TypedActionService {
+class MockService<T: JanetAction>: TypedActionService {
   typealias ServiceAction = T
   typealias SendableStub = (ActionServiceCallback?, ActionHolder<ServiceAction>) throws -> Void
   typealias CancelableStub = (ActionHolder<ServiceAction>) -> Void

--- a/Tests/SwiftyJanetTests/TestExtensions/ActionPair+Equatable.swift
+++ b/Tests/SwiftyJanetTests/TestExtensions/ActionPair+Equatable.swift
@@ -1,5 +1,5 @@
 @testable import SwiftyJanet
 
-func == <T: Equatable> (lhs: ActionPair<T>, rhs: ActionPair<T>) -> Bool {
+func == <T: JanetAction> (lhs: ActionPair<T>, rhs: ActionPair<T>) -> Bool {
   return (lhs.0 == rhs.0) && (lhs.1 == rhs.1)
 }


### PR DESCRIPTION
Implements #17:
- Add JanetAction typealias
- Replace single character action type generics with 'Action' word
- Remove unused enum associated values in ActionState