### PR TITLE
Rework JanetAction to be a protocol

### DIFF
--- a/Sources/ActionHolder.swift
+++ b/Sources/ActionHolder.swift
@@ -1,6 +1,15 @@
 import Foundation
 
-public struct ActionHolder <Action: JanetAction> {
+public protocol OriginComparable {
+  associatedtype Act: JanetAction
+  
+  var origin: Act { get }
+  func isOrigin(action: Any) -> Bool
+}
+
+public struct ActionHolder <Action: JanetAction>: OriginComparable {
+  public typealias Act = Action
+  
   public let origin: Action
   public var modified: Action
   
@@ -9,16 +18,17 @@ public struct ActionHolder <Action: JanetAction> {
                         modified: action)
   }
   
-  func isOrigin(action: Any) -> Bool {
+  public func isOrigin(action: Any) -> Bool {
     guard let castedAction = action as? Action else {
       return false
     }
-    return self.origin == castedAction
+    return self.origin.isEqual(to: castedAction)
   }
 }
 
 extension ActionHolder: Equatable {
   public static func == (lhs: ActionHolder<Action>, rhs: ActionHolder<Action>) -> Bool {
-    return lhs.origin == rhs.origin && lhs.modified == rhs.modified
+    return lhs.origin.isEqual(to: rhs.origin) &&
+           lhs.modified.isEqual(to: rhs.modified)
   }
 }

--- a/Sources/JanetTypes.swift
+++ b/Sources/JanetTypes.swift
@@ -1,7 +1,21 @@
 import Foundation
 import RxSwift
 
-public typealias JanetAction = Equatable
+public protocol JanetAction {
+  func isEqual(to action: Self) -> Bool
+}
+
+extension JanetAction where Self: AnyObject {
+  public func isEqual(to action: Self) -> Bool {
+    return self === action
+  }
+}
+
+extension JanetAction where Self: Equatable {
+  public func isEqual(to action: Self) -> Bool {
+    return self == action
+  }
+}
 
 internal typealias ActionPair <Action: JanetAction> = (ActionHolder<Action>, ActionState<Action>)
 internal typealias SharedPipeline = PublishSubject<Any>

--- a/SwiftyJanet.xcodeproj/project.pbxproj
+++ b/SwiftyJanet.xcodeproj/project.pbxproj
@@ -29,6 +29,9 @@
 		6F78672A1EDC94F2003D4660 /* GenericTestLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7867281EDC94CD003D4660 /* GenericTestLoader.swift */; };
 		6F78672B1EDC94F3003D4660 /* GenericTestLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7867281EDC94CD003D4660 /* GenericTestLoader.swift */; };
 		6F78672C1EDC94F3003D4660 /* GenericTestLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7867281EDC94CD003D4660 /* GenericTestLoader.swift */; };
+		6FB416371F018976006B3ABF /* Tests+JanetAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75982D291EE6F82D0017C576 /* Tests+JanetAction.swift */; };
+		6FB416381F018976006B3ABF /* Tests+JanetAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75982D291EE6F82D0017C576 /* Tests+JanetAction.swift */; };
+		6FB416391F018977006B3ABF /* Tests+JanetAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75982D291EE6F82D0017C576 /* Tests+JanetAction.swift */; };
 		7544F1171ED5D6A1006D2318 /* ActionPair+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7544F1161ED5D6A1006D2318 /* ActionPair+Equatable.swift */; };
 		7544F1181ED5D6A1006D2318 /* ActionPair+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7544F1161ED5D6A1006D2318 /* ActionPair+Equatable.swift */; };
 		7544F1191ED5D6A1006D2318 /* ActionPair+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7544F1161ED5D6A1006D2318 /* ActionPair+Equatable.swift */; };
@@ -44,7 +47,6 @@
 		7573282D1ED86D0900283A71 /* JanetTestAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7573282B1ED86BDC00283A71 /* JanetTestAction.swift */; };
 		7573282E1ED86D0A00283A71 /* JanetTestAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7573282B1ED86BDC00283A71 /* JanetTestAction.swift */; };
 		7573282F1ED86D0A00283A71 /* JanetTestAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7573282B1ED86BDC00283A71 /* JanetTestAction.swift */; };
-		75982D2A1EE6F82D0017C576 /* Tests+JanetAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75982D291EE6F82D0017C576 /* Tests+JanetAction.swift */; };
 		75B1A2531ED48FCE003126B6 /* ActionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B1A2521ED48FCE003126B6 /* ActionStateTests.swift */; };
 		75B1A2581ED49146003126B6 /* ActionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B1A2571ED49146003126B6 /* ActionState.swift */; };
 		75B1A2591ED49146003126B6 /* ActionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B1A2571ED49146003126B6 /* ActionState.swift */; };
@@ -766,7 +768,6 @@
 			files = (
 				6F7867271ED756D6003D4660 /* ActionPipe.swift in Sources */,
 				75C22FEE1ED59FD4008B4FCB /* JanetTypes.swift in Sources */,
-				75982D2A1EE6F82D0017C576 /* Tests+JanetAction.swift in Sources */,
 				75E325FC1ED6E4AF0082F8B2 /* TakeWhileInclusive.swift in Sources */,
 				6F78671B1ED4C610003D4660 /* JanetError.swift in Sources */,
 				75B1A25E1ED49392003126B6 /* ActionHolder.swift in Sources */,
@@ -795,6 +796,7 @@
 				6F78672A1EDC94F2003D4660 /* GenericTestLoader.swift in Sources */,
 				75C230031ED5B582008B4FCB /* TypedActionServiceTests.swift in Sources */,
 				757328261ED863A600283A71 /* JanetTestCase.swift in Sources */,
+				6FB416371F018976006B3ABF /* Tests+JanetAction.swift in Sources */,
 				75B1A2631ED49688003126B6 /* ActionServiceCallbackTests.swift in Sources */,
 				6F7867141ED4BF23003D4660 /* TestErrors.swift in Sources */,
 				7544F1171ED5D6A1006D2318 /* ActionPair+Equatable.swift in Sources */,
@@ -867,6 +869,7 @@
 				6F78672B1EDC94F3003D4660 /* GenericTestLoader.swift in Sources */,
 				75C230041ED5B59D008B4FCB /* TypedActionServiceTests.swift in Sources */,
 				757328271ED863A600283A71 /* JanetTestCase.swift in Sources */,
+				6FB416381F018976006B3ABF /* Tests+JanetAction.swift in Sources */,
 				6F7867131ED4BF22003D4660 /* TestErrors.swift in Sources */,
 				6F7867161ED4BF29003D4660 /* ActionStateTests.swift in Sources */,
 				7544F1181ED5D6A1006D2318 /* ActionPair+Equatable.swift in Sources */,
@@ -891,6 +894,7 @@
 				6F78672C1EDC94F3003D4660 /* GenericTestLoader.swift in Sources */,
 				75C230051ED5B59D008B4FCB /* TypedActionServiceTests.swift in Sources */,
 				757328281ED863A600283A71 /* JanetTestCase.swift in Sources */,
+				6FB416391F018977006B3ABF /* Tests+JanetAction.swift in Sources */,
 				6F7867151ED4BF24003D4660 /* TestErrors.swift in Sources */,
 				6F7867171ED4BF29003D4660 /* ActionStateTests.swift in Sources */,
 				7544F1191ED5D6A1006D2318 /* ActionPair+Equatable.swift in Sources */,

--- a/SwiftyJanet.xcodeproj/project.pbxproj
+++ b/SwiftyJanet.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		7573282D1ED86D0900283A71 /* JanetTestAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7573282B1ED86BDC00283A71 /* JanetTestAction.swift */; };
 		7573282E1ED86D0A00283A71 /* JanetTestAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7573282B1ED86BDC00283A71 /* JanetTestAction.swift */; };
 		7573282F1ED86D0A00283A71 /* JanetTestAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7573282B1ED86BDC00283A71 /* JanetTestAction.swift */; };
+		75982D2A1EE6F82D0017C576 /* Tests+JanetAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75982D291EE6F82D0017C576 /* Tests+JanetAction.swift */; };
 		75B1A2531ED48FCE003126B6 /* ActionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B1A2521ED48FCE003126B6 /* ActionStateTests.swift */; };
 		75B1A2581ED49146003126B6 /* ActionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B1A2571ED49146003126B6 /* ActionState.swift */; };
 		75B1A2591ED49146003126B6 /* ActionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B1A2571ED49146003126B6 /* ActionState.swift */; };
@@ -154,6 +155,7 @@
 		7573281E1ED8421C00283A71 /* RxTest+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RxTest+Extensions.swift"; sourceTree = "<group>"; };
 		757328251ED863A600283A71 /* JanetTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JanetTestCase.swift; sourceTree = "<group>"; };
 		7573282B1ED86BDC00283A71 /* JanetTestAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JanetTestAction.swift; sourceTree = "<group>"; };
+		75982D291EE6F82D0017C576 /* Tests+JanetAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Tests+JanetAction.swift"; sourceTree = "<group>"; };
 		75B1A2521ED48FCE003126B6 /* ActionStateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionStateTests.swift; sourceTree = "<group>"; };
 		75B1A2571ED49146003126B6 /* ActionState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionState.swift; sourceTree = "<group>"; };
 		75B1A25D1ED49392003126B6 /* ActionHolder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionHolder.swift; sourceTree = "<group>"; };
@@ -313,6 +315,7 @@
 				7573281E1ED8421C00283A71 /* RxTest+Extensions.swift */,
 				75E037721EDC49850078FFA8 /* RxTest+ActionState.swift */,
 				75E037771EDC620F0078FFA8 /* ActionServiceCallback+Stub.swift */,
+				75982D291EE6F82D0017C576 /* Tests+JanetAction.swift */,
 			);
 			path = TestExtensions;
 			sourceTree = "<group>";
@@ -763,6 +766,7 @@
 			files = (
 				6F7867271ED756D6003D4660 /* ActionPipe.swift in Sources */,
 				75C22FEE1ED59FD4008B4FCB /* JanetTypes.swift in Sources */,
+				75982D2A1EE6F82D0017C576 /* Tests+JanetAction.swift in Sources */,
 				75E325FC1ED6E4AF0082F8B2 /* TakeWhileInclusive.swift in Sources */,
 				6F78671B1ED4C610003D4660 /* JanetError.swift in Sources */,
 				75B1A25E1ED49392003126B6 /* ActionHolder.swift in Sources */,

--- a/Tests/SwiftyJanetTests/Base/JanetTestAction.swift
+++ b/Tests/SwiftyJanetTests/Base/JanetTestAction.swift
@@ -1,8 +1,9 @@
 import Foundation
+import SwiftyJanet
 
-class JanetTestAction { }
+class JanetTestAction: JanetAction { }
 
-extension JanetTestAction: Equatable {
+extension JanetTestAction {
   static func == (lhs: JanetTestAction, rhs: JanetTestAction) -> Bool {
     return lhs === rhs
   }

--- a/Tests/SwiftyJanetTests/TestExtensions/ActionState+Equatable.swift
+++ b/Tests/SwiftyJanetTests/TestExtensions/ActionState+Equatable.swift
@@ -4,13 +4,13 @@ extension ActionState: Equatable {
   public static func == (lhs: ActionState, rhs: ActionState) -> Bool {
     switch (lhs, rhs) {
     case (let .start(a1), let .start(a2)):
-      return a1 == a2
+      return a1.isEqual(to: a2)
     case (let .progress(a1, p1), let .progress(a2, p2)):
-      return a1 == a2 && p1 == p2
+      return a1.isEqual(to: a2) && p1 == p2
     case (let .success(a1), let .success(a2)):
-      return a1 == a2
+      return a1.isEqual(to: a2)
     case (let .error(a1, e1), let .error(a2, e2)):
-      return a1 == a2 && type(of: e1.self) == type(of: e2.self)
+      return a1.isEqual(to: a2) && type(of: e1.self) == type(of: e2.self)
     default:
       return false
     }

--- a/Tests/SwiftyJanetTests/TestExtensions/RxTest+Extensions.swift
+++ b/Tests/SwiftyJanetTests/TestExtensions/RxTest+Extensions.swift
@@ -2,8 +2,8 @@ import SwiftyJanet
 import RxSwift
 import RxTest
 
-typealias TestStateObservable<T: Equatable> = TestableObservable<ActionState<T>>
-typealias TestStateObserver<T: Equatable> = TestableObserver<ActionState<T>>
+typealias TestStateObservable<T: JanetAction> = TestableObservable<ActionState<T>>
+typealias TestStateObserver<T: JanetAction> = TestableObserver<ActionState<T>>
 
-typealias TestStateEvent<T: Equatable> = RxSwift.Event<ActionState<T>>
-typealias TestStateRecorded<T: Equatable> = RxTest.Recorded<TestStateEvent<T>>
+typealias TestStateEvent<T: JanetAction> = RxSwift.Event<ActionState<T>>
+typealias TestStateRecorded<T: JanetAction> = RxTest.Recorded<TestStateEvent<T>>

--- a/Tests/SwiftyJanetTests/TestExtensions/Tests+JanetAction.swift
+++ b/Tests/SwiftyJanetTests/TestExtensions/Tests+JanetAction.swift
@@ -1,3 +1,4 @@
+import SwiftyJanet
 import Foundation
 
 extension String: JanetAction {}

--- a/Tests/SwiftyJanetTests/TestExtensions/Tests+JanetAction.swift
+++ b/Tests/SwiftyJanetTests/TestExtensions/Tests+JanetAction.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+extension String: JanetAction {}
+extension Int: JanetAction {}
+extension Double: JanetAction {}


### PR DESCRIPTION
- Make JanetAction a protocol
- Replace Equatable requirement with isEqual(to:) method and protocol
  extension that will use == for Equatable actions and === for reference types.
- Fix unit tests